### PR TITLE
Allow to define Godge server URL using the GODGE_URL env var

### DIFF
--- a/cmd/godge/main.go
+++ b/cmd/godge/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/subcommands"
 )
 
-var serverAddress = flag.String("address", "", "The address of the server")
+var serverAddress = flag.String("address", os.Getenv("GODGE_ADDR"), "The address of the server")
 
 func main() {
 	subcommands.ImportantFlag("address")


### PR DESCRIPTION
I find it tiresome to have to send the `address` argument with every call to the godge client cmd, so I propose to enable to define it using an environment variable, `GODGE_ADDR`.