### PR TITLE
Allow to define Godge username and password using env vars

### DIFF
--- a/cmd/godge/register.go
+++ b/cmd/godge/register.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/MohamedBassem/godge"
 	"github.com/google/subcommands"
@@ -27,8 +28,8 @@ func (*registerCmd) Usage() string {
 }
 
 func (s *registerCmd) SetFlags(f *flag.FlagSet) {
-	f.StringVar(&s.username, "username", "", "The username you want to register with")
-	f.StringVar(&s.password, "password", "", "The password you want to register with")
+	f.StringVar(&s.username, "username", os.Getenv("GODGE_USERNAME"), "The username you want to register with")
+	f.StringVar(&s.password, "password", os.Getenv("GODGE_PASSWORD"), "The password you want to register with")
 }
 
 func (s *registerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {

--- a/cmd/godge/submit.go
+++ b/cmd/godge/submit.go
@@ -32,8 +32,8 @@ func (*submitCmd) Usage() string {
 func (s *submitCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&s.language, "language", "", "The language of the submission")
 	f.StringVar(&s.taskName, "task", "", "The task of the submission")
-	f.StringVar(&s.username, "username", "", "Your username")
-	f.StringVar(&s.password, "password", "", "Your password")
+	f.StringVar(&s.username, "username", os.Getenv("GODGE_USERNAME"), "Your username")
+	f.StringVar(&s.password, "password", os.Getenv("GODGE_PASSWORD"), "Your password")
 }
 
 func (s *submitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {


### PR DESCRIPTION
Similar to #1, but for the `username` and `password` using `GODGE_USERNAME` and `GODGE_PASSWORD` respectively.